### PR TITLE
fix upgrade and add ut for sync status

### DIFF
--- a/pkg/manager/member/tikv_upgrader.go
+++ b/pkg/manager/member/tikv_upgrader.go
@@ -173,7 +173,8 @@ func (u *tikvUpgrader) upgradeTiKVPod(tc *v1alpha1.TidbCluster, ordinal int32, n
 		return controller.RequeueErrorf("upgradeTiKVPod: evicting leader of pod %s for tc %s/%s", upgradePodName, ns, tcName)
 	}
 
-	if err := u.modifyVolumesBeforeUpgrade(tc, upgradePod); err != nil {
+	done, err = u.modifyVolumesBeforeUpgrade(tc, upgradePod)
+	if err != nil {
 		return fmt.Errorf("upgradeTiKVPod: failed to modify volumes of pod %s for tc %s/%s, error: %s", upgradePodName, ns, tcName, err)
 	}
 	if !done {
@@ -227,18 +228,23 @@ func (u *tikvUpgrader) evictLeaderBeforeUpgrade(tc *v1alpha1.TidbCluster, upgrad
 	return false, nil
 }
 
-func (u *tikvUpgrader) modifyVolumesBeforeUpgrade(tc *v1alpha1.TidbCluster, upgradePod *corev1.Pod) error {
+func (u *tikvUpgrader) modifyVolumesBeforeUpgrade(tc *v1alpha1.TidbCluster, upgradePod *corev1.Pod) (bool, error) {
 	desiredVolumes, err := u.volumeModifier.GetDesiredVolumes(tc, v1alpha1.TiKVMemberType)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	actual, err := u.volumeModifier.GetActualVolumes(upgradePod, desiredVolumes)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	return u.volumeModifier.Modify(actual)
+	if u.volumeModifier.ShouldModify(actual) {
+		err := u.volumeModifier.Modify(actual)
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (u *tikvUpgrader) beginEvictLeader(tc *v1alpha1.TidbCluster, storeID uint64, pod *corev1.Pod) error {

--- a/pkg/manager/volumes/fake_pod_vol_modifier.go
+++ b/pkg/manager/volumes/fake_pod_vol_modifier.go
@@ -28,7 +28,7 @@ func (pvm *FakePodVolumeModifier) ShouldModify(actual []ActualVolume) bool {
 	if pvm.ShouldModifyFunc == nil {
 		return false
 	}
-	return pvm.ShouldModify(actual)
+	return pvm.ShouldModifyFunc(actual)
 }
 
 func (pvm *FakePodVolumeModifier) Modify(actual []ActualVolume) error {

--- a/pkg/manager/volumes/sync_volume_status_test.go
+++ b/pkg/manager/volumes/sync_volume_status_test.go
@@ -1,0 +1,264 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volumes
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pingcap/tidb-operator/pkg/apis/pingcap/v1alpha1"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestObserveVolumeStatus(t *testing.T) {
+	desiredSC := "desired-sc"
+	actualSC := "actual-sc"
+	desiredSize := "20Gi"
+	actualSize := "10Gi"
+
+	type testcase struct {
+		input  func(*FakePodVolumeModifier) ([]*v1.Pod, []DesiredVolume)
+		expect func(*GomegaWithT, map[v1alpha1.StorageVolumeName]*v1alpha1.ObservedStorageVolumeStatus)
+	}
+
+	cases := map[string]testcase{
+		"all volumes are modified": {
+			input: func(pvm *FakePodVolumeModifier) ([]*v1.Pod, []DesiredVolume) {
+				pods := newPods("pod", 3)
+
+				desiredVolumes := []DesiredVolume{
+					{
+						Name:         "vol1",
+						Size:         desiredSize,
+						StorageClass: newStorageClass(desiredSC, true),
+					},
+					{
+						Name:         "vol2",
+						Size:         desiredSize,
+						StorageClass: newStorageClass(desiredSC, true),
+					},
+				}
+				pvm.GetActualVolumesFunc = func(pod *corev1.Pod, vs []DesiredVolume) ([]ActualVolume, error) {
+					index := strings.Split(pod.Name, "-")[1]
+					// all volumes are modified
+					return []ActualVolume{
+						{
+							Desired: &desiredVolumes[0],
+							PVC:     newPVC(fmt.Sprintf("vol1-%s", index), desiredSC, desiredSize, desiredSize),
+						},
+						{
+							Desired: &desiredVolumes[1],
+							PVC:     newPVC(fmt.Sprintf("vol2-%s", index), desiredSC, desiredSize, desiredSize),
+						},
+					}, nil
+				}
+
+				return pods, desiredVolumes
+			},
+			expect: func(g *GomegaWithT, observedStatus map[v1alpha1.StorageVolumeName]*v1alpha1.ObservedStorageVolumeStatus) {
+				expectStatus := map[v1alpha1.StorageVolumeName]*v1alpha1.ObservedStorageVolumeStatus{
+					"vol1": {
+						BoundCount:           3,
+						CurrentCount:         3,
+						ModifiedCount:        3,
+						CurrentCapacity:      resource.MustParse(desiredSize),
+						ModifiedCapacity:     resource.MustParse(desiredSize),
+						CurrentStorageClass:  desiredSC,
+						ModifiedStorageClass: desiredSC,
+						ResizedCount:         3,
+						ResizedCapacity:      resource.MustParse(desiredSize),
+					},
+					"vol2": {
+						BoundCount:           3,
+						CurrentCount:         3,
+						ModifiedCount:        3,
+						CurrentCapacity:      resource.MustParse(desiredSize),
+						ModifiedCapacity:     resource.MustParse(desiredSize),
+						CurrentStorageClass:  desiredSC,
+						ModifiedStorageClass: desiredSC,
+						ResizedCount:         3,
+						ResizedCapacity:      resource.MustParse(desiredSize),
+					},
+				}
+
+				g.Expect(cmp.Diff(expectStatus, observedStatus)).To(BeEmpty(), "(-want, +got)")
+			},
+		},
+		"some volumes is modifying": {
+			input: func(pvm *FakePodVolumeModifier) ([]*v1.Pod, []DesiredVolume) {
+				pods := newPods("pod", 3)
+
+				desiredVolumes := []DesiredVolume{
+					{
+						Name:         "vol1",
+						Size:         desiredSize,
+						StorageClass: newStorageClass(desiredSC, true),
+					},
+					{
+						Name:         "vol2",
+						Size:         desiredSize,
+						StorageClass: newStorageClass(desiredSC, true),
+					},
+					{
+						Name:         "vol3",
+						Size:         desiredSize,
+						StorageClass: newStorageClass(desiredSC, true),
+					},
+				}
+				pvm.GetActualVolumesFunc = func(pod *corev1.Pod, vs []DesiredVolume) ([]ActualVolume, error) {
+					index := strings.Split(pod.Name, "-")[1]
+
+					switch index {
+					case "0": // volumes of pod 0 are modified
+						return []ActualVolume{
+							{
+								Desired: &desiredVolumes[0],
+								PVC:     newPVC(fmt.Sprintf("vol1-%s", index), desiredSC, desiredSize, desiredSize),
+							},
+							{
+								Desired: &desiredVolumes[1],
+								PVC:     newPVC(fmt.Sprintf("vol2-%s", index), desiredSC, desiredSize, desiredSize),
+							},
+							{
+								Desired: &desiredVolumes[2],
+								PVC:     newPVC(fmt.Sprintf("vol3-%s", index), desiredSC, desiredSize, desiredSize),
+							},
+						}, nil
+					default: // other volumes of pod 1 are modifying or not modified
+						return []ActualVolume{
+							{
+								Desired: &desiredVolumes[0],
+								PVC:     newPVC(fmt.Sprintf("vol1-%s", index), desiredSC, actualSize, actualSize), // size is not modified
+							},
+							{
+								Desired: &desiredVolumes[1],
+								PVC:     newPVC(fmt.Sprintf("vol2-%s", index), actualSC, desiredSize, desiredSize), // sc is not modified
+							},
+							{
+								Desired: &desiredVolumes[2],
+								PVC:     newPVC(fmt.Sprintf("vol3-%s", index), actualSC, actualSize, actualSize), // size and sc are not modified
+							},
+						}, nil
+					}
+
+				}
+
+				return pods, desiredVolumes
+			},
+			expect: func(g *GomegaWithT, observedStatus map[v1alpha1.StorageVolumeName]*v1alpha1.ObservedStorageVolumeStatus) {
+				expectStatus := map[v1alpha1.StorageVolumeName]*v1alpha1.ObservedStorageVolumeStatus{
+					"vol1": {
+						BoundCount:           3,
+						CurrentCount:         2,
+						ModifiedCount:        1,
+						CurrentCapacity:      resource.MustParse(actualSize),
+						ModifiedCapacity:     resource.MustParse(desiredSize),
+						CurrentStorageClass:  desiredSC,
+						ModifiedStorageClass: desiredSC,
+						ResizedCount:         1,
+						ResizedCapacity:      resource.MustParse(desiredSize),
+					},
+					"vol2": {
+						BoundCount:           3,
+						CurrentCount:         2,
+						ModifiedCount:        1,
+						CurrentCapacity:      resource.MustParse(desiredSize),
+						ModifiedCapacity:     resource.MustParse(desiredSize),
+						CurrentStorageClass:  actualSC,
+						ModifiedStorageClass: desiredSC,
+						ResizedCount:         1,
+						ResizedCapacity:      resource.MustParse(desiredSize),
+					},
+					"vol3": {
+						BoundCount:           3,
+						CurrentCount:         2,
+						ModifiedCount:        1,
+						CurrentCapacity:      resource.MustParse(actualSize),
+						ModifiedCapacity:     resource.MustParse(desiredSize),
+						CurrentStorageClass:  actualSC,
+						ModifiedStorageClass: desiredSC,
+						ResizedCount:         1,
+						ResizedCapacity:      resource.MustParse(desiredSize),
+					},
+				}
+
+				g.Expect(cmp.Diff(expectStatus, observedStatus)).To(BeEmpty(), "(-want, +got)")
+			},
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			pvm := &FakePodVolumeModifier{}
+			pods, desiredVolumes := c.input(pvm)
+			observedStatus := ObserveVolumeStatus(pvm, pods, desiredVolumes)
+			c.expect(g, observedStatus)
+		})
+	}
+}
+
+func newPods(baseName string, count int) []*v1.Pod {
+	pods := make([]*v1.Pod, 0, count)
+	for i := 0; i < count; i++ {
+		pods = append(pods, &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%d", baseName, i),
+				Namespace: "test",
+			},
+		})
+	}
+	return pods
+}
+
+func newPVC(name, storageClass, request, capacity string) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: v1.NamespaceDefault,
+			Name:      name,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse(request),
+				},
+			},
+			StorageClassName: pointer.StringPtr(storageClass),
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse(capacity),
+			},
+		},
+	}
+}
+
+func newStorageClass(name string, expandable bool) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		AllowVolumeExpansion: pointer.BoolPtr(expandable),
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
