### PR TITLE
fix crd

### DIFF
--- a/pkg/apis/pingcap/v1alpha1/types.go
+++ b/pkg/apis/pingcap/v1alpha1/types.go
@@ -2582,19 +2582,25 @@ type ObservedStorageVolumeStatus struct {
 	// +optional
 	CurrentCount int `json:"currentCount"`
 	// ModifiedCount is the count of modified volumes.
+	// +optional
 	ModifiedCount int `json:"modifiedCount"`
 	// CurrentCapacity is the current capacity of the volume.
 	// If any volume is resizing, it is the capacity before resizing.
 	// If all volumes are resized, it is the resized capacity and same as desired capacity.
+	// +optional
 	CurrentCapacity resource.Quantity `json:"currentCapacity"`
 	// ModifiedCapacity is the modified capacity of the volume.
+	// +optional
 	ModifiedCapacity resource.Quantity `json:"modifiedCapacity"`
 	// CurrentStorageClass is the modified capacity of the volume.
+	// +optional
 	CurrentStorageClass string `json:"currentStorageClass"`
 	// ModifiedStorageClass is the modified storage calss of the volume.
+	// +optional
 	ModifiedStorageClass string `json:"modifiedStorageClass"`
 
 	// (Deprecated) ResizedCapacity is the desired capacity of the volume.
+	// +optional
 	ResizedCapacity resource.Quantity `json:"resizedCapacity"`
 	// (Deprecated) ResizedCount is the count of volumes whose capacity is equal to `resizedCapacity`.
 	// +optional

--- a/pkg/manager/member/tikv_member_manager.go
+++ b/pkg/manager/member/tikv_member_manager.go
@@ -774,7 +774,9 @@ func (m *tikvMemberManager) syncTiKVClusterStatus(tc *v1alpha1.TidbCluster, set 
 	if tc.TiKVStsDesiredReplicas() != *set.Spec.Replicas {
 		tc.Status.TiKV.Phase = v1alpha1.ScalePhase
 	} else if upgrading && tc.Status.PD.Phase != v1alpha1.UpgradePhase {
-		tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
+		if !tc.IsComponentLeaderEvicting(v1alpha1.TiKVMemberType) { // skip upgrade if someone is evicting leader
+			tc.Status.TiKV.Phase = v1alpha1.UpgradePhase
+		}
 	} else {
 		tc.Status.TiKV.Phase = v1alpha1.NormalPhase
 	}

--- a/pkg/manager/volumes/pvc_modifier.go
+++ b/pkg/manager/volumes/pvc_modifier.go
@@ -71,6 +71,11 @@ func (p *pvcModifier) Sync(tc *v1alpha1.TidbCluster) error {
 	errs := []error{}
 
 	for _, comp := range components {
+		if comp.MemberType() == v1alpha1.TiKVMemberType && tc.Status.TiKV.Phase == v1alpha1.UpgradePhase {
+			klog.Infof("skip to modify volumes for cluster %s/%s because cluster is upgrading", tc.Namespace, tc.Name)
+			continue
+		}
+
 		ctx, err := p.buildContextForTC(tc, comp)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("build ctx used by modifier for %s failed: %w", ctx.ComponentID(), err))

--- a/pkg/manager/volumes/sync_volume_status_test.go
+++ b/pkg/manager/volumes/sync_volume_status_test.go
@@ -212,7 +212,7 @@ func TestObserveVolumeStatus(t *testing.T) {
 			g := NewGomegaWithT(t)
 			pvm := &FakePodVolumeModifier{}
 			pods, desiredVolumes := c.input(pvm)
-			observedStatus := ObserveVolumeStatus(pvm, pods, desiredVolumes)
+			observedStatus := observeVolumeStatus(pvm, pods, desiredVolumes)
 			c.expect(g, observedStatus)
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?
<!--
Please describe the problem AS DETAILED AS POSSIBLE.
Add an ISSUE LINK WITH SUMMARY if exists.

For example:

    Fix the bug that syncing `Backup` CR will crash tidb-controller-manager pod when client TLS feature is enabled.

    Closes #xxx (issue number)
-->

### What is changed and how does it work?
<!--
Please describe the design that your implementation follows AS DETAILED AS POSSIBLE.

For example:

    The root cause is a nil pointer dereferencing. Add a `ptr != nil` check before access members of `ptr` to prevent the crash.
-->

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note

```
